### PR TITLE
Refactor commands to improve readability 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": "^7.2.5",
         "laravel/framework": ">=7.0",
-        "guzzlehttp/guzzle": "^6.3.1|^7.0"
+        "guzzlehttp/guzzle": "^6.3.1|^7.0",
+        "ext-zend-opcache": "*"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0",

--- a/src/Commands/Clear.php
+++ b/src/Commands/Clear.php
@@ -32,13 +32,10 @@ class Clear extends Command
     {
         $response = $this->sendRequest('clear');
         $response->throw();
-
-        if ($response['result']) {
-            $this->info('OPcache cleared');
-        } else {
+        if (!$response->successful()) {
             $this->error('OPcache not configured');
-
             return 2;
         }
+        $this->info('OPcache cleared');
     }
 }

--- a/src/Commands/Compile.php
+++ b/src/Commands/Compile.php
@@ -33,16 +33,16 @@ class Compile extends Command
         $response = $this->sendRequest('compile', ['force' => $this->option('force') ?? false]);
         $response->throw();
 
-        if (isset($response['result']['message'])) {
-            $this->warn($response['result']['message']);
-
-            return 1;
-        } elseif ($response['result']) {
-            $this->info(sprintf('%s of %s files compiled', $response['result']['compiled_count'], $response['result']['total_files_count']));
-        } else {
+        if (!$response->successful()) {
             $this->error('OPcache not configured');
-
             return 2;
         }
+
+        if (isset($response['result']['message'])) {
+            $this->warn($response['result']['message']);
+            return 1;
+        }
+
+        $this->info(sprintf('%s of %s files compiled', $response['result']['compiled_count'], $response['result']['total_files_count']));
     }
 }

--- a/src/Commands/Config.php
+++ b/src/Commands/Config.php
@@ -33,17 +33,15 @@ class Config extends Command
         $response = $this->sendRequest('config');
         $response->throw();
 
-        if ($response['result']) {
-            $this->line('Version info:');
-            $this->table([], $this->parseTable($response['result']['version']));
-
-            $this->line(PHP_EOL.'Configuration info:');
-            $this->table([], $this->parseTable($response['result']['directives']));
-        } else {
+        if (!$response->successful()) {
             $this->error('OPcache not configured');
-
             return 2;
         }
+
+        $this->line('Version info:');
+        $this->table([], $this->parseTable($response['result']['version']));
+        $this->line(PHP_EOL.'Configuration info:');
+        $this->table([], $this->parseTable($response['result']['directives']));
     }
 
     /**
@@ -58,18 +56,22 @@ class Config extends Command
         $input = (array) $input;
 
         return array_map(function ($key, $value) {
-            $bytes = ['opcache.memory_consumption'];
-
-            if (in_array($key, $bytes)) {
-                $value = number_format($value / 1048576, 2).' MB';
-            } elseif (is_bool($value)) {
-                $value = $value ? 'true' : 'false';
-            }
-
             return [
                 'key'       => $key,
-                'value'     => $value,
+                'value'     => $this->parseValue($key, $value),
             ];
         }, array_keys($input), $input);
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @return string
+     */
+    protected function parseValue($key, $value) {
+        if (in_array($key, ['opcache.memory_consumption'])) {
+            return number_format($value / 1048576, 2).' MB';
+        }
+        return $value ? 'true' : 'false';
     }
 }

--- a/src/CreatesRequest.php
+++ b/src/CreatesRequest.php
@@ -10,14 +10,22 @@ trait CreatesRequest
     /**
      * @param $url
      * @param $parameters
-     * @return \Appstract\LushHttp\Response\LushResponse
+     * @return \Illuminate\Http\Client\Response
      */
     public function sendRequest($url, $parameters = [])
     {
         return Http::withHeaders(config('opcache.headers'))
             ->withOptions(['verify' => config('opcache.verify')])
-            ->get(rtrim(config('opcache.url'), '/').'/'.trim(config('opcache.prefix'), '/').'/'.ltrim($url, '/'),
+            ->get($this->buildEndpoint($url),
                 array_merge(['key' => Crypt::encrypt('opcache')], $parameters)
         );
+    }
+
+    /**
+     * @param string $url
+     * @return string
+     */
+    protected function buildEndpoint(string $url): string {
+        return rtrim(config('opcache.url'), '/').'/'.trim(config('opcache.prefix'), '/').'/'.ltrim($url, '/');
     }
 }

--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -52,7 +52,6 @@ class OpcacheClass
         }
 
         if (function_exists('opcache_compile_file')) {
-            $compiled = 0;
 
             // Get files in these paths
             $files = collect(Finder::create()->in(config('opcache.directories'))
@@ -64,20 +63,17 @@ class OpcacheClass
                 ->followLinks());
 
             // optimized files
-            $files->each(function ($file) use (&$compiled) {
-                try {
-                    if (! opcache_is_script_cached($file)) {
-                        opcache_compile_file($file);
-                    }
-
-                    $compiled++;
-                } catch (\Exception $e) {
+            $compiled = $files->filter(function ($file) {
+                if (opcache_is_script_cached($file)) {
+                    return false;
                 }
+                @opcache_compile_file($file);
+                return true;
             });
 
             return [
                 'total_files_count' => $files->count(),
-                'compiled_count' => $compiled,
+                'compiled_count' => $compiled->count(),
             ];
         }
     }

--- a/tests/ClearTest.php
+++ b/tests/ClearTest.php
@@ -13,6 +13,6 @@ class ClearTest extends TestCase
 
         $output = Artisan::output();
 
-        $this->assertContains('cleared', $output);
+        $this->assertStringContainsString('cleared', $output);
     }
 }

--- a/tests/CompileTest.php
+++ b/tests/CompileTest.php
@@ -13,6 +13,6 @@ class CompileTest extends TestCase
 
         $output = Artisan::output();
 
-        $this->assertContains('files compiled', $output);
+        $this->assertStringContainsString('files compiled', $output);
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -13,7 +13,7 @@ class ConfigTest extends TestCase
 
         $output = Artisan::output();
 
-        $this->assertContains('Version info', $output);
-        $this->assertContains('Configuration info', $output);
+        $this->assertStringContainsString('Version info', $output);
+        $this->assertStringContainsString('Configuration info', $output);
     }
 }

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -13,8 +13,8 @@ class StatusTest extends TestCase
 
         $output = Artisan::output();
 
-        $this->assertContains('Memory usage:', $output);
-        $this->assertContains('Interned strings usage:', $output);
-        $this->assertContains('Statistics:', $output);
+        $this->assertStringContainsString('Memory usage:', $output);
+        $this->assertStringContainsString('Interned strings usage:', $output);
+        $this->assertStringContainsString('Statistics:', $output);
     }
 }


### PR DESCRIPTION
I realised that some code could be improved its readability. So, I decided just to improve some logic giving more an aspect of [defensive programming](https://en.wikipedia.org/wiki/Defensive_programming) and no using else's.

- Add ext-zend-opcache on composer as requirement.
- Fix deprecated phpunit functions

Hope that it could help this package.